### PR TITLE
Context değişkeni döndürmeye çalışıyor

### DIFF
--- a/MusicMarket.Data/Repositories/ArtistRepository.cs
+++ b/MusicMarket.Data/Repositories/ArtistRepository.cs
@@ -30,7 +30,8 @@ namespace MusicMarket.Data.Repositories
 
         private MusicMarketDbContext MusicMarketDbContext
         {
-            get { return Context as MusicMarketDbContext; }
+            //get { return Context as MusicMarketDbContext; }
+            get { return MusicMarketDbContext as MusicMarketDbContext;}
         }
     }
 }


### PR DESCRIPTION
Method içlerinde MusicMarketDbContext olarak kullanıldığı için MusicMarketDbContext  döndürmesi gerekirken Context olarak yazım yanlışı kalmış gibi. 
Context olarak tanımlamak daha güzel olurdu aslında. 

bir diğer alternatif olarak DependencyInjection ile yapabilirmiydik burada ? Aşağıda bir örnek bırakıyorum..

        private MusicMarketDbContext _context;

        public ArtistRepository(MusicMarketDbContext context)
            : base(context)
        {
            _context = context;

        }

        public async Task<IEnumerable<Artist>> GetAllWithMusicAsync()
        {
            return await _context.Artists.Include(a => a.Musics).ToListAsync();

        }

        public async Task<Artist> GetWithMusicsByIdAsync(int id)
        {
            return await _context.Artists.Include(a => a.Musics).SingleOrDefaultAsync(a => a.Id == id);
        }